### PR TITLE
rc2: bug fix of parsing curve-nbd command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all
 
 CSI_IMAGE_NAME=$(if $(ENV_CSI_IMAGE_NAME),$(ENV_CSI_IMAGE_NAME),quay.io/curvecsi/curve-csi)
-CSI_IMAGE_VERSION=$(if $(ENV_CSI_IMAGE_VERSION),$(ENV_CSI_IMAGE_VERSION),csi-v1.1.0-rc1)
+CSI_IMAGE_VERSION=$(if $(ENV_CSI_IMAGE_VERSION),$(ENV_CSI_IMAGE_VERSION),csi-v1.1.0-rc2)
 
 GO_PROJECT=github.com/opencurve/curve-csi
 GIT_COMMIT=$(shell git rev-parse --short HEAD)

--- a/deploy/kubernetes/v1.13/node-plugin-daemonset.yaml
+++ b/deploy/kubernetes/v1.13/node-plugin-daemonset.yaml
@@ -52,7 +52,7 @@ spec:
           capabilities:
             add: ["SYS_ADMIN"]
           allowPrivilegeEscalation: true
-        image: quay.io/curvecsi/curve-csi:csi-v1.1.0-rc1
+        image: quay.io/curvecsi/curve-csi:csi-v1.1.0-rc2
         args:
         - --endpoint=$(CSI_ENDPOINT)
         - --drivername=curve.csi.netease.com

--- a/deploy/kubernetes/v1.13/provisioner-sts.yaml
+++ b/deploy/kubernetes/v1.13/provisioner-sts.yaml
@@ -77,7 +77,7 @@ spec:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        image: quay.io/curvecsi/curve-csi:csi-v1.1.0-rc1
+        image: quay.io/curvecsi/curve-csi:csi-v1.1.0-rc2
         args:
         - --endpoint=$(CSI_ENDPOINT)
         - --drivername=curve.csi.netease.com

--- a/deploy/kubernetes/v1.14+/node-plugin-daemonset.yaml
+++ b/deploy/kubernetes/v1.14+/node-plugin-daemonset.yaml
@@ -52,7 +52,7 @@ spec:
           capabilities:
             add: ["SYS_ADMIN"]
           allowPrivilegeEscalation: true
-        image: quay.io/curvecsi/curve-csi:csi-v1.1.0-rc1
+        image: quay.io/curvecsi/curve-csi:csi-v1.1.0-rc2
         args:
         - --endpoint=$(CSI_ENDPOINT)
         - --drivername=curve.csi.netease.com

--- a/deploy/kubernetes/v1.14+/provisioner-deploy.yaml
+++ b/deploy/kubernetes/v1.14+/provisioner-deploy.yaml
@@ -82,7 +82,7 @@ spec:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        image: quay.io/curvecsi/curve-csi:csi-v1.1.0-rc1
+        image: quay.io/curvecsi/curve-csi:csi-v1.1.0-rc2
         args:
         - --endpoint=$(CSI_ENDPOINT)
         - --drivername=curve.csi.netease.com

--- a/pkg/curveservice/curveservie-utils.go
+++ b/pkg/curveservice/curveservie-utils.go
@@ -70,8 +70,10 @@ func waitForMapped(ctx context.Context, filePath, user string, maxRetries int) (
 			time.Sleep(time.Second)
 		}
 
-		if devicePath, _ := getNbdDevFromFileName(ctx, filePath, user); devicePath != "" {
+		if devicePath, err := getNbdDevFromFileName(ctx, filePath, user); devicePath != "" {
 			return devicePath, true
+		} else if err != nil {
+			klog.Warning(err)
 		}
 	}
 	return "", false
@@ -92,7 +94,7 @@ func getNbdDevFromFileName(ctx context.Context, filePath, user string) (string, 
 			continue
 		}
 		lineSlice := strings.Fields(tLine)
-		if len(lineSlice) != 3 {
+		if len(lineSlice) < 3 {
 			continue
 		}
 		// cbdMapPathSuffix: /k8s/csi-vol-pvc-647525be-c0d6-464b-b548-1fa26f6d183c_k8s_


### PR DESCRIPTION
bug fix of parsing output of `curve-nbd list-mapped`.

previous output:

```
id      image                                                                device
1509297 cbd:k8s//k8s/csi-vol-pvc-647525be-c0d6-464b-b548-1fa26f6d183c_k8s_ /dev/nbd1
```

now adding options:

```
id      image                                                                device options
1509297 cbd:k8s//k8s/csi-vol-pvc-647525be-c0d6-464b-b548-1fa26f6d183c_k8s_ /dev/nbd1 timeout=86400
```

