### PR TITLE
Modify image register domain because CNCF ecosystem projects has migrated.

### DIFF
--- a/charts/curve-csi/values.yaml
+++ b/charts/curve-csi/values.yaml
@@ -14,7 +14,7 @@ nodeplugin:
     resources: {}
 
   registrar:
-    image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+    image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
     # add resources limit
     resources: {}
 
@@ -44,22 +44,22 @@ controllerplugin:
     resources: {}
 
   provisioner:
-    image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+    image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
     # add resources limit
     resources: {}
 
   attacher:
-    image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+    image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
     # add resources limit
     resources: {}
   
   resizer:
-    image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+    image: registry.k8s.io/sig-storage/csi-resizer:v1.2.0
     # add resources limit
     resources: {}
   
   snapshotter:
-    image: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
+    image: registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3
     # add resources limit
     resources: {}
 

--- a/deploy/manifests/node-plugin-daemonset.yaml
+++ b/deploy/manifests/node-plugin-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: driver-registrar
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
         securityContext:
           privileged: true
         args:

--- a/deploy/manifests/provisioner-deploy.yaml
+++ b/deploy/manifests/provisioner-deploy.yaml
@@ -30,7 +30,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: csi-provisioner
-        image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
         args:
         - "--csi-address=$(ADDRESS)"
         - "--v=5"
@@ -45,7 +45,7 @@ spec:
         - name: socket-dir
           mountPath: /csi
       - name: csi-attacher
-        image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
         args:
         - "--v=5"
         - "--csi-address=$(ADDRESS)"
@@ -62,7 +62,7 @@ spec:
         - name: socket-dir
           mountPath: /csi
       - name: csi-resizer
-        image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.2.0
         args:
         - "--csi-address=$(ADDRESS)"
         - "--v=5"
@@ -81,7 +81,7 @@ spec:
         - name: socket-dir
           mountPath: /csi
       - name: csi-snapshotter
-        image: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3
         args:
           - "--csi-address=$(ADDRESS)"
           - "--v=5"

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -13,9 +13,9 @@ For snapshot functionality to be supported for your Kubernetes cluster, the Kube
 
 |Latest stable release	|Min CSI Version	|Max CSI Version	|Container Image	|Min K8s Version	|Max K8s Version	|Recommended K8s Version|
 | ---	| --- 	| ---	| ---	| --- |---	|---|
-|v4.2.1	|	v1.0.0	|-	|k8s.gcr.io/sig-storage/snapshot-controller:v4.2.1|	v1.20	|-	|v1.22|
-| v4.1.1|	v1.0.0	|-	|k8s.gcr.io/sig-storage/snapshot-controller:v4.1.1|	v1.20|	-	|v1.20|
-| v3.0.3 (beta)|	v1.0.0|	-|	k8s.gcr.io/sig-storage/snapshot-controller:v3.0.3	|v1.17	|-|	v1.17|
+|v4.2.1	|	v1.0.0	|-	|registry.k8s.io/sig-storage/snapshot-controller:v4.2.1|	v1.20	|-	|v1.22|
+| v4.1.1|	v1.0.0	|-	|registry.k8s.io/sig-storage/snapshot-controller:v4.1.1|	v1.20|	-	|v1.20|
+| v3.0.3 (beta)|	v1.0.0|	-|	registry.k8s.io/sig-storage/snapshot-controller:v3.0.3	|v1.17	|-|	v1.17|
 
 
 **Install Snapshot Beta CRDs:**


### PR DESCRIPTION
Modify image register because official image registry has migrated from k8s.gcr.io to registry.k8s.io. See more details at  [https://github.com/kubernetes/k8s.io/issues/4780](https://github.com/kubernetes/k8s.io/issues/4780)