### PR TITLE
fix createVolume error when snapshotServer is empty

### DIFF
--- a/pkg/curve/controllerserver.go
+++ b/pkg/curve/controllerserver.go
@@ -417,10 +417,7 @@ func (cs *controllerServer) createVolFromContentSource(
 	req *csi.CreateVolumeRequest,
 	destVolOptions *volumeOptions,
 	curveVol *curveservice.CurveVolume) (volSource string, err error) {
-	if cs.snapshotServer == "" {
-		return "", status.Error(codes.Unimplemented, "")
-	}
-
+	
 	if req.VolumeContentSource == nil {
 		return "", nil
 	}
@@ -429,6 +426,10 @@ func (cs *controllerServer) createVolFromContentSource(
 	// check contentSource
 	switch req.VolumeContentSource.Type.(type) {
 	case *csi.VolumeContentSource_Snapshot:
+		if cs.snapshotServer == "" {
+			return "", status.Error(codes.Unimplemented, "")
+		}
+
 		snapshotId := req.VolumeContentSource.GetSnapshot().GetSnapshotId()
 		// lock out parallel snapshot
 		if acquired := cs.snapshotLocks.TryAcquire(snapshotId); !acquired {


### PR DESCRIPTION
ControllerServer run with no snapshotServer:
>./curve-csi --endpoint=unix:///csi/csi-provisioner.sock --drivername=curve.csi.netease.com --nodeid=172.16.5.8 --snapshot-server= --controller-server=true --debug-port=9696 -v=5

If I don't install snapshot-server, createVolume will return error:
>GRPC error" err="rpc error: code = Unimplemented desc = "